### PR TITLE
fix: marvin wont trigger pr review ping

### DIFF
--- a/.github/workflows/notify-slack-on-pr-review-request.yaml
+++ b/.github/workflows/notify-slack-on-pr-review-request.yaml
@@ -59,7 +59,7 @@ jobs:
           IFS=',' read -r -a reviewers <<< "${{ inputs.reviewers }}"
           
           # Skip if triggered by marvin
-          if [ "$requester" = "marvin-serp-bto" ]; then
+          if [ "$requester" = "marvin-serp-bot" ]; then
             echo "Requester is Marvin, skipping notification."
             exit 0
           fi


### PR DESCRIPTION
Marvin will no longer trigger the pr-review-request workflow ping. 